### PR TITLE
Release/1.1.9

### DIFF
--- a/edd-status-board.php
+++ b/edd-status-board.php
@@ -9,10 +9,19 @@ Author URI: https://easydigitaldownloads.com
 License: GPLv2 or later
 */
 
-if ( class_exists( 'Easy_Digital_Downloads' ) && version_compare( EDD_VERSION, '2.4', '>=' ) ) {
-	add_filter( 'edd_api_valid_query_modes', 'edd_statusboard_mode' );
-	add_filter( 'edd_api_output_data', 'edd_statusboard_output', 10, 2 );
-	add_action( 'show_user_profile',   'edd_statusboard_profile_endpoint_display' );
+add_action( 'init', 'edd_statusboard_init' );
+/**
+ * Initializes the plugin.
+ *
+ * @since 1.1.9
+ * @return void
+ */
+function edd_statusboard_init() {
+	if ( class_exists( 'Easy_Digital_Downloads' ) && version_compare( EDD_VERSION, '2.4', '>=' ) ) {
+		add_filter( 'edd_api_valid_query_modes', 'edd_statusboard_mode' );
+		add_filter( 'edd_api_output_data', 'edd_statusboard_output', 10, 2 );
+		add_action( 'show_user_profile', 'edd_statusboard_profile_endpoint_display' );
+	}
 }
 
 function edd_statusboard_mode( $modes ) {

--- a/edd-status-board.php
+++ b/edd-status-board.php
@@ -258,7 +258,7 @@ function edd_statusboard_profile_endpoint_display( $user ) {
 	}
 }
 
-function edd_statusboard_format_datapoints( $title = false, $datapoints, $color = 'green' ) {
+function edd_statusboard_format_datapoints( $title, $datapoints, $color = 'green' ) {
 	$return = array();
 
 	$return['title'] = $title;

--- a/edd-status-board.php
+++ b/edd-status-board.php
@@ -1,11 +1,11 @@
 <?php
 /*
 Plugin Name: Easy Digital Downloads - Status Board
-Plugin URI: https://easydigitaldownloads.com/downloads/status-board/
+Plugin URI: https://wordpress.org/plugins/edd-status-board/
 Description: Integrates the Easy Digital Downloads API with the Status Board iPad App.
 Version: 1.1.8
-Author: Easy Digital Downloads
-Author URI: https://easydigitaldownloads.com
+Author: Sandhills Development, LLC
+Author URI: https://sandhillsdev.com
 License: GPLv2 or later
 */
 

--- a/edd-status-board.php
+++ b/edd-status-board.php
@@ -9,7 +9,7 @@ Author URI: https://easydigitaldownloads.com
 License: GPLv2 or later
 */
 
-add_action( 'init', 'edd_statusboard_init' );
+add_action( 'plugins_loaded', 'edd_statusboard_init' );
 /**
  * Initializes the plugin.
  *

--- a/edd-status-board.php
+++ b/edd-status-board.php
@@ -1,13 +1,13 @@
 <?php
-/*
-Plugin Name: Easy Digital Downloads - Status Board
-Plugin URI: https://wordpress.org/plugins/edd-status-board/
-Description: Integrates the Easy Digital Downloads API with the Status Board iPad App.
-Version: 1.1.8
-Author: Sandhills Development, LLC
-Author URI: https://sandhillsdev.com
-License: GPLv2 or later
-*/
+/**
+ * Plugin Name: Easy Digital Downloads - Status Board
+ * Plugin URI: https://wordpress.org/plugins/edd-status-board/
+ * Description: Integrates the Easy Digital Downloads API with the Status Board iPad App.
+ * Version: 1.1.9
+ * Author: Sandhills Development, LLC
+ * Author URI: https://sandhillsdev.com
+ * License: GPLv2 or later
+ */
 
 add_action( 'plugins_loaded', 'edd_statusboard_init' );
 /**

--- a/readme.txt
+++ b/readme.txt
@@ -12,6 +12,8 @@ Integrate the Easy Digital Downloads API with the Status Board iPad app from Pan
 
 EDD - Status Board Integrates the Easy Digital Downloads API with the Status Board iPad app.
 
+**Please note:** The Status Board app has been discontinued and is no longer available. If you already own it, this extension should work with it, but this extension will not be updated in the future.
+
 Using your Easy Digital Downloads API Key and Tokens, you can display 3 different bar graphs:
 
 * Last 7 days sales
@@ -89,13 +91,6 @@ You can manually add them to Status Board, or use the buttons located in the Pro
 
 = 1.0 =
 * Initial Release
-
-== Frequently Asked Questions ==
-
-= Do I have to buy the app for iOS for iPad =
-
-Yes, this plugin requires that you buy the Status Board application by Panic. Their app is only available for iPad. You can download it directly from the App Store:
-https://itunes.apple.com/us/app/status-board/id449955536?mt=8
 
 == Screenshots ==
 1. View of the Hybrid Graph

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: easydigitaldownloads, cklosows, mordauk
 Tags: status board, panic, easy digital downloads, edd, ios, ipad
 Requires at least: 3.0
 Tested up to: 5.7
-Stable tag: 1.1.8
+Stable tag: 1.1.9
 License: GPLv2 or later
 
 Integrate the Easy Digital Downloads API with the Status Board iPad app from Panic.
@@ -50,6 +50,12 @@ You can manually add them to Status Board, or use the buttons located in the Pro
 
 
 == Changelog ==
+= 1.1.9 =
+* The readme has been updated to note that the Status Board app is no longer for sale. Therefore this add-on will no longer be maintained after this update.
+* Plugin author information has been updated.
+* Fix: Deprecation notices in PHP 8.
+* Fix: Undefined constant warning.
+
 = 1.1.8 =
 * FIX: Make compatible with PHP 7.1
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: easydigitaldownloads, cklosows, mordauk
 Tags: status board, panic, easy digital downloads, edd, ios, ipad
 Requires at least: 3.0
-Tested up to: 4.7.2
+Tested up to: 5.7
 Stable tag: 1.1.8
 License: GPLv2 or later
 


### PR DESCRIPTION
Closes https://github.com/easydigitaldownloads/edd-status-board/milestone/3?closed=1

| Issue # | Description |
|---------|-------------|
| #18 | PHP 8 errors: Required parameter $datapoints follows optional parameter $title |
| #17 | Status Board app is no longer for sale |
| #14 | Update plugin information |
| #13 | Undefined constant PHP notice |
